### PR TITLE
Fix Dockerfile npm install issues

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,7 +3,8 @@ node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
-package-lock.json
+# Keep package-lock.json for npm ci
+# package-lock.json
 
 # Build outputs
 dist/

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -7,10 +7,10 @@ WORKDIR /app
 RUN apk add --no-cache python3 make g++
 
 # Copy package files
-COPY package*.json ./
+COPY package.json ./
 
 # Install production dependencies
-RUN npm ci --only=production
+RUN npm install --production --legacy-peer-deps
 
 # Copy server code
 COPY server/ ./server/

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -4,10 +4,10 @@ FROM node:18-alpine AS builder
 WORKDIR /app
 
 # Copy package files
-COPY package*.json ./
+COPY package.json ./
 
 # Install dependencies
-RUN npm ci
+RUN npm install --legacy-peer-deps
 
 # Copy source code
 COPY . .


### PR DESCRIPTION
- Change from npm ci to npm install (no package-lock.json in repo)
- Add --legacy-peer-deps flag for compatibility
- Update .dockerignore to keep package-lock.json if present
- Both frontend and backend Dockerfiles updated

🤖 Generated with [Claude Code](https://claude.ai/code)